### PR TITLE
fix: add missing serde attributes on structs

### DIFF
--- a/src/model/error_state.rs
+++ b/src/model/error_state.rs
@@ -1,6 +1,7 @@
 use num_enum::TryFromPrimitive;
 use strum::Display;
 
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Eq, PartialEq, TryFromPrimitive, Copy, Clone, Ord, PartialOrd, Hash, Display)]
 #[repr(u64)]
 pub enum ErrorState {

--- a/src/model/mode.rs
+++ b/src/model/mode.rs
@@ -1,6 +1,7 @@
 use num_enum::TryFromPrimitive;
 use strum::Display;
 
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Eq, PartialEq, TryFromPrimitive, Copy, Clone, Ord, PartialOrd, Hash, Display)]
 #[repr(u64)]
 pub enum Mode {

--- a/src/model/solar_charger_state.rs
+++ b/src/model/solar_charger_state.rs
@@ -4,6 +4,7 @@ use crate::err::*;
 use super::error_state::ErrorState;
 use super::mode::Mode;
 
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
 pub struct SolarChargerState{
     pub mode: Mode,

--- a/src/model/test_record_state.rs
+++ b/src/model/test_record_state.rs
@@ -1,6 +1,7 @@
 use crate::bit_reader::BitReader;
 use crate::err::*;
 
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct TestRecordState{
     pub uptime_s: u64,


### PR DESCRIPTION
**Description:**

Some of the structs in the crate were missing the `derive` `serde` attributes.