### PR TITLE
Fix stream ending after first event

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,9 +140,11 @@ fn handle_manufacturer_data(
             Err(e)
         },
         Ok(device_state) => {
-            let _ = sender.send(Ok(device_state));
-            // If consumer has dropped the channel then stop
-            Err(Error::ClientClosedChannel)
+            if sender.send(Ok(device_state)).is_err() {
+                // If consumer has dropped the channel then stop
+                return Err(Error::ClientClosedChannel);
+            }
+            Ok(())
         }
     }
 }


### PR DESCRIPTION
This fixes the stream so it doesn't end after the first event.