### PR TITLE
feat: add VE.Bus device support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.5.0
+
+Add: support for VE.Bus device type.
+Add: `AcInState` and `AlarmNotification` enums for VE.Bus specific states.
+
 # 0.4.1
 
 - Fix: `open_stream` hangs at 100% CPU if the bluetooth adapter is disconnected.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,7 +1199,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "victron_ble"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "victron_ble"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 repository = "https://github.com/felixwatts/victron_ble"
 description = "Read data from Victron devices over Bluetooth Low Energy."

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Currently the following device types are supported.
 - Solar Charger
 - Battery Monitor
 - Inverter
+- VE Bus
 
 ## Features
 

--- a/src/err.rs
+++ b/src/err.rs
@@ -42,6 +42,10 @@ pub enum Error {
     InvalidAuxInputType(u64),
     #[error("The data was shorter than expected.")]
     DataTooShort,
+    #[error("Invalid ac in state")]
+    InvalidAcInState,
+    #[error("Invalid alarm notification")]
+    InvalidAlarmNotification,
 }
 
 #[cfg(target_os = "macos")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,9 +30,9 @@
 //!     }
 //! # }
 //! ```
-//! 
+//!
 //! ## Device Setup
-//! 
+//!
 //! In order to turn on the Victron device's BLE state broadcasts you must enable the "Instant Readout"
 //! setting. This can be done via the Victron Connect App on iOS or Android.
 //!
@@ -43,24 +43,25 @@
 //! device using the Victron Connect app on iOS or Android.
 //!
 //! Using the app, connect to the device, then go to Settings -> Product Info -> Encryption data.
-//! 
+//!
 //! ## Supported Device Types
-//! 
+//!
 //! Currently the following device types are supported. Support can be added for other device types if requested.
-//! 
+//!
 //! - Solar Charger
 //! - Battery Monitor
 //! - Inverter
+//! - VE Bus
 //!
 //! ## Features
 //!
 //! ### `bluetooth`
 //!
-//! Adds the `open_stream` function which handles all of the bluetooth discovery and receiving 
-//! but is only supported for the `macos` and `linux` targets. With the `bluetooth` feature off 
-//! you still get the `parse_manufacturer_data` function but you must source your own 
-//! manufacturer data packet. 
-//! 
+//! Adds the `open_stream` function which handles all of the bluetooth discovery and receiving
+//! but is only supported for the `macos` and `linux` targets. With the `bluetooth` feature off
+//! you still get the `parse_manufacturer_data` function but you must source your own
+//! manufacturer data packet.
+//!
 //! `bluetooth` is a default feature.
 //!
 //! ### `serde`

--- a/src/model/device_state.rs
+++ b/src/model/device_state.rs
@@ -5,6 +5,7 @@ use super::battery_monitor_state::BatteryMonitorState;
 use super::inverter_state::InverterState;
 use super::solar_charger_state::SolarChargerState;
 use super::test_record_state::TestRecordState;
+use super::ve_bus_state::VeBusState;
 
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -13,6 +14,7 @@ pub enum DeviceState {
     SolarCharger(SolarChargerState),
     BatteryMonitor(BatteryMonitorState),
     Inverter(InverterState),
+    VeBus(VeBusState),
 }
 
 impl DeviceState {
@@ -28,6 +30,7 @@ impl DeviceState {
                 &record.decrypt()?,
             )?)),
             RECORD_TYPE_INVERTER => Ok(Self::Inverter(InverterState::parse(&record.decrypt()?)?)),
+            RECORD_TYPE_VE_BUS => Ok(Self::VeBus(VeBusState::parse(&record.decrypt()?)?)),
             _ => Err(Error::UnsupportedDeviceType(record.record_type())),
         }
     }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -6,6 +6,7 @@ mod inverter_state;
 mod mode;
 mod solar_charger_state;
 mod test_record_state;
+mod ve_bus_state;
 
 pub use alarm_reason::AlarmReason;
 pub use battery_monitor_state::BatteryMonitorState;
@@ -15,3 +16,4 @@ pub use inverter_state::InverterState;
 pub use mode::Mode;
 pub use solar_charger_state::SolarChargerState;
 pub use test_record_state::TestRecordState;
+pub use ve_bus_state::VeBusState;

--- a/src/model/ve_bus_state.rs
+++ b/src/model/ve_bus_state.rs
@@ -1,0 +1,108 @@
+use crate::bit_reader::BitReader;
+use crate::err::*;
+use num_enum::TryFromPrimitive;
+
+use super::mode::Mode;
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
+pub struct VeBusState {
+    pub mode: Mode,
+    pub error: u8,
+    pub battery_voltage_v: f32,
+    pub battery_current_a: f32,
+    pub ac_in_state: AcInState,
+    pub ac_in_power_w: f32,
+    pub ac_out_power_w: f32,
+    pub alarm: AlarmNotification,
+    pub battery_temperature_c: f32,
+    pub soc_percent: f32,
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, TryFromPrimitive)]
+#[repr(u8)]
+pub enum AcInState {
+    AcIn1 = 0,
+    AcIn2 = 1,
+    NotConnected = 2,
+    Unknown = 3,
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, TryFromPrimitive)]
+#[repr(u8)]
+pub enum AlarmNotification {
+    NoAlarm = 0,
+    Warning = 1,
+    Alarm = 2,
+    NotApplicable = 3,
+}
+
+impl VeBusState {
+    pub(crate) fn parse(payload: &[u8]) -> Result<Self> {
+        let mut reader = BitReader::new(payload);
+
+        let mode = Mode::try_from(reader.read_unsigned_int(8)?)?;
+        let error = reader.read_unsigned_int(8)? as u8;
+        let battery_current_a = (reader.read_signed_int(16)? as f32) / 10.0;
+        let battery_voltage_v = (reader.read_unsigned_int(14)? as f32) / 100.0;
+        let ac_in_state = AcInState::try_from(reader.read_unsigned_int(2)? as u8)
+            .ok()
+            .ok_or(Error::InvalidAcInState)?;
+        let ac_in_power_w = reader.read_signed_int(19)? as f32;
+        let ac_out_power_w = reader.read_signed_int(19)? as f32;
+        let alarm = AlarmNotification::try_from(reader.read_unsigned_int(2)? as u8)
+            .ok()
+            .ok_or(Error::InvalidAlarmNotification)?;
+        let battery_temperature_c = reader.read_unsigned_int(7)? as f32 - 40.0;
+        let soc_percent = reader.read_unsigned_int(7)? as f32;
+
+        Ok(Self {
+            mode,
+            error,
+            battery_voltage_v,
+            battery_current_a,
+            ac_in_state,
+            ac_in_power_w,
+            ac_out_power_w,
+            alarm,
+            battery_temperature_c,
+            soc_percent,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    // Raw: [05, 00, 16, 00, 46, 05, 2f, 00, 00, 00, 00, c2, ff, c1, 16, 11]
+    // Expected values from your app:
+    // - Mode: Float (5)
+    // - Battery: 13.49V, 2.2A
+    // - AC Output: 2W
+    // - Temperature: 26°C
+    #[test]
+    fn test_ve_bus_parse() {
+        let test_data = [
+            0x05, 0x00, 0x16, 0x00, 0x46, 0x05, 0x2f, 0x00, 0x00, 0x00, 0x00, 0xc2, 0xff, 0xc1,
+            0x16, 0x11,
+        ];
+
+        let result = VeBusState::parse(&test_data).unwrap();
+
+        assert_eq!(result.mode, Mode::Float);
+        assert_eq!(result.error, 0);
+
+        assert!((result.battery_voltage_v - 13.50).abs() < 0.1);
+
+        assert!((result.battery_current_a - 2.2).abs() < 0.1);
+
+        assert_eq!(result.ac_in_state, AcInState::AcIn1);
+
+        assert!((result.battery_temperature_c - 26.0).abs() < 2.0);
+
+        assert_eq!(result.alarm, AlarmNotification::NoAlarm);
+    }
+}

--- a/src/record.rs
+++ b/src/record.rs
@@ -6,6 +6,7 @@ pub(crate) const RECORD_TYPE_TEST_RECORD: u8 = 0x00;
 pub(crate) const RECORD_TYPE_SOLAR_CHARGER: u8 = 0x01;
 pub(crate) const RECORD_TYPE_BATTERY_MONITOR: u8 = 0x02;
 pub(crate) const RECORD_TYPE_INVERTER: u8 = 0x03;
+pub(crate) const RECORD_TYPE_VE_BUS: u8 = 0x0C;
 
 const MANUFACTURER_DATA_RECORD_TYPE: u8 = 0x10;
 


### PR DESCRIPTION
- Add `VeBusState`
- Add `AcInState` and `AlarmNotification` enums for VE.Bus specific states
- Add `RECORD_TYPE_VE_BUS` constant for device type 0x0C (12)
- Support for battery voltage, current, temperature, SOC, AC power, and alarm states
- Update changelog for v0.5.0

Tested locally with VE.Bus device:

Command:
```
cargo run --example bluetooth <victron device name> <victron device encryption key>
```

Output:
```
Ok(VeBus(VeBusState { mode: Float, error: 0, battery_voltage_v: 13.49, battery_current_a: 3.6, ac_in_state: Disconnected, ac_in_power_w: 57.0, ac_out_power_w: 1.0, alarm: NoAlarm, battery_temperature_c: 26.0, soc_percent: 0.0 }))
```