### PR TITLE
feat: support device type ac charger (8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Currently the following device types are supported. **Support can be added for o
 - Solar Charger
 - Battery Monitor
 - Inverter
+- AC Charger
 - VE Bus
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -4,29 +4,34 @@ Read data from Victron devices over Bluetooth Low Energy.
 
 Some Victron devices broadcast some aspects of their state over Bluetooth on a regular basis. This crate makes it easy to access that data.
 
+This crate is intended to work on Linux and macOS devices. 
+
 ## Basic Usage
 
 Use the `open_stream` function to get a stream of state updates for a given
 Victron device:
 
 ```rust
-use std::{println, time::Duration};
 use tokio_stream::StreamExt;
 
 #[tokio::main]
 async fn main() {
     let device_name = "Victron Bluetooth device name".into();
-    let device_encryption_key = hex::decode("00"/* Victron device encryption key. See below. */).unwrap();
+    let device_encryption_key =
+        hex::decode("00" /* Victron device encryption key. See below. */).unwrap();
 
-    let mut device_state_stream = victron_ble::open_stream(
-        device_name,
-        device_encryption_key
-    ).unwrap();
+    let mut device_state_stream =
+        victron_ble::open_stream(device_name, device_encryption_key).unwrap();
 
     while let Some(result) = device_state_stream.next().await {
         println!("{result:?}");
     }
 }
+```
+
+Add the following crates to your `Cargo.toml`:
+```
+cargo add hex tokio tokio-stream victron-ble
 ```
 
 ## Device Setup

--- a/src/model/ac_charger_state.rs
+++ b/src/model/ac_charger_state.rs
@@ -41,3 +41,52 @@ impl AcChargerState {
         })
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    // Raw: [0x04, 0x00, 0xA0, 0x05, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x1B, 0xB9, 0x2F]
+    // As recorded and checked on Blue Smart IP22 Charger
+    #[test]
+    fn test_ac_charger_state_parse_1() {
+        let test_data = [
+            0x04, 0x00, 0xA0, 0x05, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x1B,
+            0xB9, 0x2F,
+        ];
+
+        let result = AcChargerState::parse(&test_data).unwrap();
+
+        assert_eq!(result.device_error, Mode::Absorption);
+        assert_eq!(result.charger_error, ErrorState::NoError);
+
+        assert!((result.battery_voltage_1 - 14.40).abs() < 0.1);
+        assert!((result.battery_current_1).abs() < 0.11);
+        assert!((result.battery_voltage_2).abs() < 0.11);
+        assert!((result.battery_current_2).abs() < 0.11);
+        assert!((result.battery_voltage_3).abs() < 0.11);
+        assert!((result.battery_current_3).abs() < 0.11);
+    }
+
+    // Raw: [0x04, 0x00, 0xA0, 0x25, 0x03, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x74, 0xA5, 0x82]
+    // As recorded and checked on Blue Smart IP22 Charger
+    #[test]
+    fn test_ac_charger_state_parse_2() {
+        let test_data = [
+            0x04, 0x00, 0xA0, 0x25, 0x03, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x74,
+            0xA5, 0x82,
+        ];
+
+        let result = AcChargerState::parse(&test_data).unwrap();
+
+        assert_eq!(result.device_error, Mode::Absorption);
+        assert_eq!(result.charger_error, ErrorState::NoError);
+
+        assert!((result.battery_voltage_1 - 14.40).abs() < 0.1);
+        assert!((result.battery_current_1 - 2.5).abs() < 0.1);
+        assert!((result.battery_voltage_2).abs() < 0.11);
+        assert!((result.battery_current_2).abs() < 0.11);
+        assert!((result.battery_voltage_3).abs() < 0.11);
+        assert!((result.battery_current_3).abs() < 0.11);
+    }
+}

--- a/src/model/ac_charger_state.rs
+++ b/src/model/ac_charger_state.rs
@@ -1,0 +1,43 @@
+use super::error_state::ErrorState;
+use super::Mode;
+use crate::bit_reader::BitReader;
+use crate::err::*;
+
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AcChargerState {
+    pub device_error: Mode,
+    pub charger_error: ErrorState,
+    pub battery_voltage_1: f32,
+    pub battery_current_1: f32,
+    pub battery_voltage_2: f32,
+    pub battery_current_2: f32,
+    pub battery_voltage_3: f32,
+    pub battery_current_3: f32,
+}
+
+impl AcChargerState {
+    pub(crate) fn parse(payload: &[u8]) -> Result<Self> {
+        let mut reader = BitReader::new(payload);
+
+        let device_error = Mode::try_from(reader.read_unsigned_int(8)?)?;
+        let charger_error = ErrorState::try_from(reader.read_unsigned_int(8)?)?;
+        let battery_voltage_1 = reader.read_signed_int(13)? as f32 / 100.0;
+        let battery_current_1 = reader.read_signed_int(11)? as f32 / 10.0;
+        let battery_voltage_2 = reader.read_signed_int(13)? as f32 / 100.0;
+        let battery_current_2 = reader.read_signed_int(11)? as f32 / 10.0;
+        let battery_voltage_3 = reader.read_signed_int(13)? as f32 / 100.0;
+        let battery_current_3 = reader.read_signed_int(11)? as f32 / 10.0;
+
+        Ok(Self {
+            device_error,
+            charger_error,
+            battery_voltage_1,
+            battery_current_1,
+            battery_voltage_2,
+            battery_current_2,
+            battery_voltage_3,
+            battery_current_3,
+        })
+    }
+}

--- a/src/model/device_state.rs
+++ b/src/model/device_state.rs
@@ -1,6 +1,7 @@
 use crate::err::*;
 use crate::record::*;
 
+use super::ac_charger_state::AcChargerState;
 use super::battery_monitor_state::BatteryMonitorState;
 use super::inverter_state::InverterState;
 use super::solar_charger_state::SolarChargerState;
@@ -15,6 +16,7 @@ pub enum DeviceState {
     BatteryMonitor(BatteryMonitorState),
     Inverter(InverterState),
     VeBus(VeBusState),
+    AcCharger(AcChargerState),
 }
 
 impl DeviceState {
@@ -30,6 +32,9 @@ impl DeviceState {
                 &record.decrypt()?,
             )?)),
             RECORD_TYPE_INVERTER => Ok(Self::Inverter(InverterState::parse(&record.decrypt()?)?)),
+            RECORD_TYPE_AC_CHARGER => {
+                Ok(Self::AcCharger(AcChargerState::parse(&record.decrypt()?)?))
+            }
             RECORD_TYPE_VE_BUS => Ok(Self::VeBus(VeBusState::parse(&record.decrypt()?)?)),
             _ => Err(Error::UnsupportedDeviceType(record.record_type())),
         }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,3 +1,4 @@
+mod ac_charger_state;
 mod alarm_reason;
 mod battery_monitor_state;
 mod device_state;
@@ -8,6 +9,7 @@ mod solar_charger_state;
 mod test_record_state;
 mod ve_bus_state;
 
+pub use ac_charger_state::AcChargerState;
 pub use alarm_reason::AlarmReason;
 pub use battery_monitor_state::BatteryMonitorState;
 pub use device_state::DeviceState;

--- a/src/record.rs
+++ b/src/record.rs
@@ -6,6 +6,7 @@ pub(crate) const RECORD_TYPE_TEST_RECORD: u8 = 0x00;
 pub(crate) const RECORD_TYPE_SOLAR_CHARGER: u8 = 0x01;
 pub(crate) const RECORD_TYPE_BATTERY_MONITOR: u8 = 0x02;
 pub(crate) const RECORD_TYPE_INVERTER: u8 = 0x03;
+pub(crate) const RECORD_TYPE_AC_CHARGER: u8 = 0x08;
 pub(crate) const RECORD_TYPE_VE_BUS: u8 = 0x0C;
 
 const MANUFACTURER_DATA_RECORD_TYPE: u8 = 0x10;


### PR DESCRIPTION
For AC Charger devices such as the Blue Smart IP22 Chargerm, see [Issue 16](https://github.com/felixwatts/victron_ble/issues/16).

~Still needs to be tested:~
- [X] Test with target
- [X] Unit test with actual data


Printed test data for my device with payload :
` [4, 0, 160, 5, 0, 255, 255, 255, 255, 255, 255, 255, 255, 27, 185, 47] `
Result: 
```Rust
Ok(AcCharger(AcChargerState { device_error: Absorption, charger_error: NoError, battery_voltage_1: 14.4, battery_current_1: 0.0, battery_voltage_2: -0.01, battery_current_2: -0.1, battery_voltage_3: -0.01, battery_current_3: -0.1 }))
```

And with same current/charging:
`[4, 0, 160, 37, 3, 255, 255, 255, 255, 255, 255, 255, 255, 116, 165, 130]`
```Rust
Ok(AcCharger(AcChargerState { device_error: Absorption, charger_error: NoError, battery_voltage_1: 14.4, battery_current_1: 2.5, battery_voltage_2: -0.01, battery_current_2: -0.1, battery_voltage_3: -0.01, battery_current_3: -0.1 }))
```